### PR TITLE
allowSyntheticDefaultImports by default

### DIFF
--- a/_docs/quick-start.md
+++ b/_docs/quick-start.md
@@ -45,6 +45,7 @@ We recommend that you write your TypeScript in [VS Code](https://code.visualstud
 {
 	"compilerOptions": {
 		// required
+		"allowSyntheticDefaultImports": true,
 		"downlevelIteration": true,
 		"module": "commonjs",
 		"noLib": true,


### PR DESCRIPTION
Allows a user to define a TS library like so
```ts
export = class {};
```
Then import like so
```ts
import Event from "./Event";
```