### PR TITLE
Documentation update on Quick Start for new versions

### DIFF
--- a/_docs/quick-start.md
+++ b/_docs/quick-start.md
@@ -84,7 +84,7 @@ At the moment, we can ignore the files `package.json` and `package-lock.json`.
 }
 ```
 The `typeRoots` field must end in "node_modules/@rbxts". For example: "../node_modules/@rbxts" is valid, but "../node_modules/@roblox-ts" is not!
-{:.warn}
+{:.info}
 
 Do not change these values unless you know what you are doing!
 {:.warn}

--- a/_docs/quick-start.md
+++ b/_docs/quick-start.md
@@ -50,7 +50,7 @@ It's recommended that you don't run `rbxtsc --init` in a non-empty folder, as in
 
 3. After generation, your directory should look like this:
 
-<p align="center"><img src=https://i.imgur.com/hNPk82S.png></p>
+<p align="center"><img src=https://i.imgur.com/GZlTGWc.png></p>
 
 At the moment, we can ignore the files `package.json` and `package-lock.json`.
 

--- a/_docs/quick-start.md
+++ b/_docs/quick-start.md
@@ -52,6 +52,8 @@ It's recommended that you don't run `rbxtsc --init` in a non-empty folder, as in
 
 <p align="center"><img src=https://i.imgur.com/hNPk82S.png></p>
 
+At the moment, we can ignore the files `package.json` and `package-lock.json`.
+
 4. Open the file named `tsconfig.json` in your project folder. The contents should look similar to this:
 
 ```js

--- a/_docs/quick-start.md
+++ b/_docs/quick-start.md
@@ -55,6 +55,8 @@ We recommend that you write your TypeScript in [VS Code](https://code.visualstud
 		"noLib": true,
 		"strict": true,
 		"target": "es6",
+
+		// required, semi-configurable
 		"typeRoots": [ "node_modules/@rbxts" ],
 
 		// required, configurable
@@ -71,6 +73,9 @@ We recommend that you write your TypeScript in [VS Code](https://code.visualstud
 	}
 }
 ```
+The `typeRoots` field must end in "node_modules/@rbxts". For example: "../node_modules/@rbxts" is valid, but "../node_modules/@roblox-ts" is not!
+{:.warn}
+
 Do not change these values unless you know what you are doing!
 {:.warn}
 

--- a/_docs/quick-start.md
+++ b/_docs/quick-start.md
@@ -67,9 +67,6 @@ At the moment, we can ignore the files `package.json` and `package-lock.json`.
 		"noLib": true,
 		"strict": true,
 		"target": "es6",
-
-		// required, semi-configurable
-		// (must end in "node_modules/@rbxts")
 		"typeRoots": [ "node_modules/@rbxts" ],
 
 		// required, configurable
@@ -137,16 +134,14 @@ You should add more partitions for the sub-folders of your `out` folder. For mor
 
 The `include` folder should be placed in a shared container that can be accessed from anywhere like `ReplicatedStorage`.
 
-6. Add the folders `src`, `out` and `include` in your workspace.
-
-7. Start roblox-ts in watch mode `rbxtsc -w`
+6. Start roblox-ts in watch mode `rbxtsc -w`
 
 If you changed the `include` folder location, instead run `rbxtsc -w -i <path-to-include>` and make sure that path exists in the rojo filesystem.
 {:.warn}
 
-8. Start Rojo (`rojo serve`)
+7. Start Rojo (`rojo serve`)
 
-9. Write code!
+8. Write code!
 
 It is recommended that you peruse through the [Usage](/docs/usage/) and [Guides](/docs/guides/) sections as you get started.
 


### PR DESCRIPTION
Starting from version `0.2.4`, and consequent patches in versions `0.2.5` and `0.2.6` the "typeRoots" field is no longer enforced to be *exactly* "node_modules/@rbxts".

This change should reflect those changes, allowing users to set up more complicated file systems.