### PR TITLE
Updated workflow-issues.md to refer to key deletion

### DIFF
--- a/_docs/usage/unsupported-features.md
+++ b/_docs/usage/unsupported-features.md
@@ -12,6 +12,7 @@ Any feature that is unsupported but not listed on this page is considered a bug!
 Some of these are intended removals, others may be added in the future!
 
 - `null` (use `undefined` instead!)
+- `delete` operator for dictionary key deletion is not type-safe so not supported (use ``myDictionary[key] = undefined!;`` instead!)
 - loop labels (used by `continue` and `break`)
 - class or function prototypes
 - regular expressions

--- a/_docs/usage/unsupported-features.md
+++ b/_docs/usage/unsupported-features.md
@@ -12,7 +12,7 @@ Any feature that is unsupported but not listed on this page is considered a bug!
 Some of these are intended removals, others may be added in the future!
 
 - `null` (use `undefined` instead!)
-- `delete` operator for dictionary key deletion is not type-safe so not supported (You should use a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) where possible)
+- `delete` operator for dictionary key deletion is not type-safe so not supported (You should use a [Map](https://roblox-ts.github.io/types/interfaces/_es_d_.map.html) where possible)
 - loop labels (used by `continue` and `break`)
 - class or function prototypes
 - regular expressions

--- a/_docs/usage/unsupported-features.md
+++ b/_docs/usage/unsupported-features.md
@@ -12,7 +12,7 @@ Any feature that is unsupported but not listed on this page is considered a bug!
 Some of these are intended removals, others may be added in the future!
 
 - `null` (use `undefined` instead!)
-- `delete` operator for dictionary key deletion is not type-safe so not supported (You should use a [Map](https://roblox-ts.github.io/types/interfaces/_es_d_.map.html) where possible)
+- `delete` operator for dictionary key deletion is not type-safe so not supported (You should use a [Map](/types/interfaces/_es_d_.map.html) where possible)
 - loop labels (used by `continue` and `break`)
 - class or function prototypes
 - regular expressions

--- a/_docs/usage/unsupported-features.md
+++ b/_docs/usage/unsupported-features.md
@@ -12,7 +12,7 @@ Any feature that is unsupported but not listed on this page is considered a bug!
 Some of these are intended removals, others may be added in the future!
 
 - `null` (use `undefined` instead!)
-- `delete` operator for dictionary key deletion is not type-safe so not supported (use ``myDictionary[key] = undefined!;`` instead!)
+- `delete` operator for dictionary key deletion is not type-safe so not supported (You should use a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) where possible)
 - loop labels (used by `continue` and `break`)
 - class or function prototypes
 - regular expressions

--- a/_docs/usage/workflow-issues.md
+++ b/_docs/usage/workflow-issues.md
@@ -26,6 +26,18 @@ Any file in your project has the ability to import any given module file. You ca
 
 However, a `ModuleScript` inside of `game.ServerStorage` should not be accessible by a `LocalScript`.
 
+## Array key deletions should be done with `myArray[key] = undefined!;`
+As the delete operator is *not* type-safe, the compiler **does not** support the `delete` operator.
+For example, your TypeScript-friendly key deletion:
+```ts
+delete myArray[key];
+```
+will not compile.
+Instead, that should be:
+```ts
+myArray[key] = undefined!;
+```
+*(refer to [`issue #547`](https://github.com/roblox-ts/roblox-ts/issues/547) for more information)*
 ## Objects May Only Have String Keys
 In TypeScript, objects may only have string keys, and arrays may only have numerical keys. This contrasts heavily with the wild west of Lua tables, where the keys can be mixed and of any type. In roblox-ts (and TypeScript), we can solve this problem by using a [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) object. Maps are objects that hold arbitrary key-value pairs of data. They also support generic types:
 

--- a/_docs/usage/workflow-issues.md
+++ b/_docs/usage/workflow-issues.md
@@ -26,18 +26,6 @@ Any file in your project has the ability to import any given module file. You ca
 
 However, a `ModuleScript` inside of `game.ServerStorage` should not be accessible by a `LocalScript`.
 
-## Array key deletions should be done with `myArray[key] = undefined!;`
-As the delete operator is *not* type-safe, the compiler **does not** support the `delete` operator.
-For example, your TypeScript-friendly key deletion:
-```ts
-delete myArray[key];
-```
-will not compile.
-Instead, that should be:
-```ts
-myArray[key] = undefined!;
-```
-*(refer to [`issue #547`](https://github.com/roblox-ts/roblox-ts/issues/547) for more information)*
 ## Objects May Only Have String Keys
 In TypeScript, objects may only have string keys, and arrays may only have numerical keys. This contrasts heavily with the wild west of Lua tables, where the keys can be mixed and of any type. In roblox-ts (and TypeScript), we can solve this problem by using a [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) object. Maps are objects that hold arbitrary key-value pairs of data. They also support generic types:
 


### PR DESCRIPTION
Due to the unsupported behavior of the ``delete`` operator in roblox-ts to delete keys, it should be better documented for new learners that the roblox-ts equivalent is ``myArray[key] = undefined!;``

Reason for addition: I spent a good 20 minutes scraping through the discord to try and find the supported method of key deletion.

(Please refer to https://github.com/roblox-ts/roblox-ts/issues/547 for more information)