### PR TITLE
Updated (most) references to mozilla to our own docs

### DIFF
--- a/_docs/index.md
+++ b/_docs/index.md
@@ -9,7 +9,7 @@ roblox-ts aims to have feature parity with [TypeScript](http://www.typescriptlan
 
 When writing code with roblox-ts, all Lua built-in functions and APIs are available as well as the entire Roblox API.
 
-These docs contain a list of articles specific to roblox-ts usage. If you're looking for more general TypeScript information, please refer to the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/basic-types.html).
+These docs contain a list of articles specific to roblox-ts usage. If you're looking for more general TypeScript information, please refer to the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/basic-types.html) or to our [own documentation](https://roblox-ts.github.io/types/modules/_es_d_.html).
 
 ## Motivation
 As Roblox games become increasingly complex and larger in scope, efficiently writing safe code becomes challenging with Lua. In addition, Lua is difficult to make tooling for. Roblox Studio attempts to provide things like intellisense and autocomplete, but it's mostly just guessing.

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -9,7 +9,7 @@ roblox-ts aims to have feature parity with [TypeScript](http://www.typescriptlan
 
 When writing code with roblox-ts, all Lua built-in functions and APIs are available as well as the entire Roblox API.
 
-These docs contain a list of articles specific to roblox-ts usage. If you're looking for more general TypeScript information, please refer to the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/basic-types.html) or to our [own documentation](https://roblox-ts.github.io/types/modules/_es_d_.html).
+These docs contain a list of articles specific to roblox-ts usage. If you're looking for more general TypeScript information, please refer to the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/basic-types.html) or to our [own documentation](/types/modules/_es_d_.html).
 
 ## Motivation
 As Roblox games become increasingly complex and larger in scope, efficiently writing safe code becomes challenging with Lua. In addition, Lua is difficult to make tooling for. Roblox Studio attempts to provide things like intellisense and autocomplete, but it's mostly just guessing.

--- a/_docs/usage/compiler-builtins.md
+++ b/_docs/usage/compiler-builtins.md
@@ -11,11 +11,11 @@ roblox-ts adds extra API that do not exist in Roblox by default, both for conven
 
 The following names exist as `new`able constructors:
 
-- `Map` ([docs](https://roblox-ts.github.io/types/interfaces/_es_d_.map.html))
+- `Map` ([docs](/types/interfaces/_es_d_.map.html))
 - `WeakMap`
-- `Set` ([docs](https://roblox-ts.github.io/types/interfaces/_es_d_.set.html))
+- `Set` ([docs](/types/interfaces/_es_d_.set.html))
 - `WeakSet`
-- `Array` ([docs](https://roblox-ts.github.io/types/interfaces/_es_d_.array.html))
+- `Array` ([docs](/types/interfaces/_es_d_.array.html))
 
 ## `typeOf`
 

--- a/_docs/usage/compiler-builtins.md
+++ b/_docs/usage/compiler-builtins.md
@@ -11,11 +11,11 @@ roblox-ts adds extra API that do not exist in Roblox by default, both for conven
 
 The following names exist as `new`able constructors:
 
-- `Map`
+- `Map` ([docs](https://roblox-ts.github.io/types/interfaces/_es_d_.map.html))
 - `WeakMap`
-- `Set`
+- `Set` ([docs](https://roblox-ts.github.io/types/interfaces/_es_d_.set.html))
 - `WeakSet`
-- `Array`
+- `Array` ([docs](https://roblox-ts.github.io/types/interfaces/_es_d_.array.html))
 
 ## `typeOf`
 

--- a/_docs/usage/math.md
+++ b/_docs/usage/math.md
@@ -7,13 +7,13 @@ description: This page explains how to represent operator overloading in TypeScr
 One of the few downsides to using TypeScript is that it does not support operator overloading.
 
 Usually this is fine, but with Roblox there are a few built-in classes that require operator overloading to use:
-- CFrame
-- UDim
-- UDim2
-- Vector2
-- Vector2int16
-- Vector3
-- Vector3int16
+- [CFrame](https://roblox-ts.github.io/types/interfaces/_roblox_d_.cframe.html) (used for Instance Translations)
+- [UDim](https://roblox-ts.github.io/types/interfaces/_roblox_d_.udim.html)
+- [UDim2](https://roblox-ts.github.io/types/interfaces/_roblox_d_.udim2.html) (Used for Roblox GUI Translation & Sizing)
+- [Vector2](https://roblox-ts.github.io/types/interfaces/_roblox_d_.vector2.html)
+- [Vector2int16](https://roblox-ts.github.io/types/interfaces/_roblox_d_.vector2int16.html)
+- [Vector3](https://roblox-ts.github.io/types/interfaces/_roblox_d_.vector3int16.html) (Used for Instance Positioning & Velocities)
+- [Vector3int16](https://roblox-ts.github.io/types/interfaces/_roblox_d_.vector3int16.html) 
 
 To get around this, roblox-ts introduces a few macro methods on each of these classes in the form of "add", "sub", "mul", and "div".
 

--- a/_docs/usage/math.md
+++ b/_docs/usage/math.md
@@ -7,13 +7,13 @@ description: This page explains how to represent operator overloading in TypeScr
 One of the few downsides to using TypeScript is that it does not support operator overloading.
 
 Usually this is fine, but with Roblox there are a few built-in classes that require operator overloading to use:
-- [CFrame](https://roblox-ts.github.io/types/interfaces/_roblox_d_.cframe.html) (used for Instance Translations)
-- [UDim](https://roblox-ts.github.io/types/interfaces/_roblox_d_.udim.html)
-- [UDim2](https://roblox-ts.github.io/types/interfaces/_roblox_d_.udim2.html) (Used for Roblox GUI Translation & Sizing)
-- [Vector2](https://roblox-ts.github.io/types/interfaces/_roblox_d_.vector2.html)
-- [Vector2int16](https://roblox-ts.github.io/types/interfaces/_roblox_d_.vector2int16.html)
-- [Vector3](https://roblox-ts.github.io/types/interfaces/_roblox_d_.vector3int16.html) (Used for Instance Positioning & Velocities)
-- [Vector3int16](https://roblox-ts.github.io/types/interfaces/_roblox_d_.vector3int16.html) 
+- [CFrame](/types/interfaces/_roblox_d_.cframe.html) (used for Instance Translations)
+- [UDim](/types/interfaces/_roblox_d_.udim.html)
+- [UDim2](h/types/interfaces/_roblox_d_.udim2.html) (Used for Roblox GUI Translation & Sizing)
+- [Vector2](/types/interfaces/_roblox_d_.vector2.html)
+- [Vector2int16](/types/interfaces/_roblox_d_.vector2int16.html)
+- [Vector3](/types/interfaces/_roblox_d_.vector3int16.html) (Used for Instance Positioning & Velocities)
+- [Vector3int16](/types/interfaces/_roblox_d_.vector3int16.html) 
 
 To get around this, roblox-ts introduces a few macro methods on each of these classes in the form of "add", "sub", "mul", and "div".
 

--- a/_docs/usage/project-structure.md
+++ b/_docs/usage/project-structure.md
@@ -9,7 +9,7 @@ It is recommended that you store your game code in a folder called `src`. This f
 
 ## Using Existing Lua code from TypeScript
 
-In order to use Lua files from TypeScript, you can create a type declaration file of the same name replacing `.lua` with `.d.ts` placed in the same directory as your Lua file. This file should contain [type declarations](https://www.typescriptlang.org/docs/handbook/declaration-files/by-example.html) for your Lua module's exported members.
+In order to use Lua files from TypeScript, you can create a type declaration file of the same name replacing `.lua` with `.d.ts` placed in the same directory as your Lua file. This file should contain [type declarations](https://www.typescriptlang.org/docs/handbook/declaration-files/by-example.html) for your Lua module's exported members (read more about typing [here](/docs/usage/types)).
 
 ## Scripts inside scripts
 Most script syncing plugins (such as Rojo) support placing scripts inside of other scripts by naming a Lua file `init.lua` inside the directory, which becomes the parent of all other files in the directory. 

--- a/_docs/usage/supported-features.md
+++ b/_docs/usage/supported-features.md
@@ -11,10 +11,10 @@ Here are some of the more notable and useful features of roblox-ts that are supp
 - [Promises](/docs/guides/promises) with `new Promise`.
 - async/await with promises.
 - Promise cancellation.
-- [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) (Also WeakMap)
-- [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) (Also WeakSet)
-- [Array methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Array_generic_methods) (.map, .filter, etc.)
-- [Object methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Array_generic_methods) (.entries, .values, .keys)
+- [Map](https://roblox-ts.github.io/types/interfaces/_es_d_.map.html) (Also WeakMap)
+- [Set](https://roblox-ts.github.io/types/interfaces/_es_d_.set.html) (Also WeakSet)
+- [Array methods](https://roblox-ts.github.io/types/interfaces/_es_d_.array.html) (.map, .filter, etc.)
+- [Object methods](https://roblox-ts.github.io/types/interfaces/_es_d_.objectconstructor.html) (.entries, .values, .keys)
 - [String methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Methods) (.concat, .split, etc.)
 - Rest/spread syntax in objects and arrays
 - [Try/catch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) and object [throws](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw)

--- a/_docs/usage/supported-features.md
+++ b/_docs/usage/supported-features.md
@@ -11,10 +11,10 @@ Here are some of the more notable and useful features of roblox-ts that are supp
 - [Promises](/docs/guides/promises) with `new Promise`.
 - async/await with promises.
 - Promise cancellation.
-- [Map](https://roblox-ts.github.io/types/interfaces/_es_d_.map.html) (Also WeakMap)
-- [Set](https://roblox-ts.github.io/types/interfaces/_es_d_.set.html) (Also WeakSet)
-- [Array methods](https://roblox-ts.github.io/types/interfaces/_es_d_.array.html) (.map, .filter, etc.)
-- [Object methods](https://roblox-ts.github.io/types/interfaces/_es_d_.objectconstructor.html) (.entries, .values, .keys)
+- [Map](/types/interfaces/_es_d_.map.html) (Also WeakMap)
+- [Set](/types/interfaces/_es_d_.set.html) (Also WeakSet)
+- [Array methods](/types/interfaces/_es_d_.array.html) (.map, .filter, etc.)
+- [Object methods](/types/interfaces/_es_d_.objectconstructor.html) (.entries, .values, .keys)
 - [String methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Methods) (.concat, .split, etc.)
 - Rest/spread syntax in objects and arrays
 - [Try/catch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) and object [throws](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw)

--- a/_docs/usage/workflow-issues.md
+++ b/_docs/usage/workflow-issues.md
@@ -27,11 +27,11 @@ Any file in your project has the ability to import any given module file. You ca
 However, a `ModuleScript` inside of `game.ServerStorage` should not be accessible by a `LocalScript`.
 
 ## Objects May Only Have String Keys
-In TypeScript, objects may only have string keys, and arrays may only have numerical keys. This contrasts heavily with the wild west of Lua tables, where the keys can be mixed and of any type. In roblox-ts (and TypeScript), we can solve this problem by using a [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) object. Maps are objects that hold arbitrary key-value pairs of data. They also support generic types:
+In TypeScript, objects may only have string keys, and arrays may only have numerical keys. This contrasts heavily with the wild west of Lua tables, where the keys can be mixed and of any type. In roblox-ts (and TypeScript), we can solve this problem by using a [`Map`](https://roblox-ts.github.io/types/interfaces/_es_d_.map.html) object. Maps are objects that hold arbitrary key-value pairs of data. They also support generic types:
 
 ```ts
 const playerMap = new Map<Player, number>()
 playerMap.set(somePlayer, 5)
 ```
 
-[`Set`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) is another useful data type that holds a set of unique values. It is akin to an array, but uniqueness is enforced.
+[`Set`](https://roblox-ts.github.io/types/interfaces/_es_d_.set.html) is another useful data type that holds a set of unique values. It is akin to an array, but uniqueness is enforced.

--- a/_docs/usage/workflow-issues.md
+++ b/_docs/usage/workflow-issues.md
@@ -27,11 +27,11 @@ Any file in your project has the ability to import any given module file. You ca
 However, a `ModuleScript` inside of `game.ServerStorage` should not be accessible by a `LocalScript`.
 
 ## Objects May Only Have String Keys
-In TypeScript, objects may only have string keys, and arrays may only have numerical keys. This contrasts heavily with the wild west of Lua tables, where the keys can be mixed and of any type. In roblox-ts (and TypeScript), we can solve this problem by using a [`Map`](https://roblox-ts.github.io/types/interfaces/_es_d_.map.html) object. Maps are objects that hold arbitrary key-value pairs of data. They also support generic types:
+In TypeScript, objects may only have string keys, and arrays may only have numerical keys. This contrasts heavily with the wild west of Lua tables, where the keys can be mixed and of any type. In roblox-ts (and TypeScript), we can solve this problem by using a [`Map`](/types/interfaces/_es_d_.map.html) object. Maps are objects that hold arbitrary key-value pairs of data. They also support generic types:
 
 ```ts
 const playerMap = new Map<Player, number>()
 playerMap.set(somePlayer, 5)
 ```
 
-[`Set`](https://roblox-ts.github.io/types/interfaces/_es_d_.set.html) is another useful data type that holds a set of unique values. It is akin to an array, but uniqueness is enforced.
+[`Set`](/types/interfaces/_es_d_.set.html) is another useful data type that holds a set of unique values. It is akin to an array, but uniqueness is enforced.


### PR DESCRIPTION
As per @evaera 's request, I ported over all available instances of references to the mozilla JS API to our own hosted at https://roblox-ts.github.io/types/modules/_es_d_.html