### PR TITLE
Updated many TS code blocks under usage to feature compiled Lua Code tabs

### DIFF
--- a/_docs/usage/behavior-changes.md
+++ b/_docs/usage/behavior-changes.md
@@ -20,18 +20,27 @@ A number of new members are present in the global scope when using roblox-ts. Yo
 
 In order to ensure a sound type-safe type system which is easy to use, 3 members of Roblox Instances have been removed. These are: `Workspace:BreakJoints()`, `Workspace:MakeJoints()` and `Instance.Changed`. The first two roblox-ts does not support because they are plugin-only and easily substituted by a for-loop. `Instance.Changed` was removed to maintain a sound type system with the `ValueBase` objects. However, Roblox-ts does support using `Instance.Changed` unsafely by intersecting Instance types with the `ChangedSignal` type. Example:
 
+{% capture code %}
 ```ts
 function f(p: Part) {
 	(p as Part & ChangedSignal).Changed.Connect(() => {})
 }
- ```
+```
+***
+```lua
+function f()
+	p.Changed.Connect(function() end)
+end
+```
+{% endcapture %}
+{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
 
 # Changes from TypeScript
 
 ## Conditional Truthiness of Empty Strings and 0
 In general, conditionals in **roblox-ts** evaluate as you'd expect them to in TS.
 
-This means that `0`, `NaN`, and empty strings (`""`) are falsy, unlike in Lua, where the only falsy values are `false` and `undefined`. [See here for a demo](https://roblox-ts.github.io/playground/#code/GYVwdgxgLglg9mABACwBQA8BcioCcQCmAlNgER6GkDcAUKJLAihtsAIYA2AzsWe9wWp1w0eEjRZEpUiSkEAtgAcoATwDKeIfVFMJ2AAyzSC5SoByIeVpGNxGAPzZwAEwLAYYAs6MnV1hmLM6I5SpIgAPoj6EYgARnBwHARsYESIAN40AJAwwIgYaZlZWbgEUCC4SOT4grRZAL6IBAIZ2VlcAO4wUBDI+eiFbVkQbDyhmEMlZRVVvuqadcUjY-oTxcWl5ZVySqoWVovDowSI-Dxr65szUme1Q8snLm4eXhcb09vGuypC667sIA4UDeUy2SAIuFwcFwqAABrE2M5EAA3TiERAAEnSqkUBAA8sACo0seh6rCiIt6tkqVSaBAEFwoIg2GQ5hpcGEALzMaQUukMpmxVnffZc5iGWj0sCMxAQYWmMVoPlSmXOeV+RDctBPdyebySgVNMgUQSa5gm5WG4B8Tg8RWoW58miKXAeKCoNgAGji3og3uc3oI3uAfKAA).
+This means that `0`, `NaN`, and empty strings (`""`) are falsy, unlike in Lua, where the only falsy values are `false` and `undefined`. [See here for a demo](/playground/#code/GYVwdgxgLglg9mABACwBQA8BcioCcQCmAlNgER6GkDcAUKJLAihtsAIYA2AzsWe9wWp1w0eEjRZEpUiSkEAtgAcoATwDKeIfVFMJ2AAyzSC5SoByIeVpGNxGAPzZwAEwLAYYAs6MnV1hmLM6I5SpIgAPoj6EYgARnBwHARsYESIAN40AJAwwIgYaZlZWbgEUCC4SOT4grRZAL6IBAIZ2VlcAO4wUBDI+eiFbVkQbDyhmEMlZRVVvuqadcUjY-oTxcWl5ZVySqoWVovDowSI-Dxr65szUme1Q8snLm4eXhcb09vGuypC667sIA4UDeUy2SAIuFwcFwqAABrE2M5EAA3TiERAAEnSqkUBAA8sACo0seh6rCiIt6tkqVSaBAEFwoIg2GQ5hpcGEALzMaQUukMpmxVnffZc5iGWj0sCMxAQYWmMVoPlSmXOeV+RDctBPdyebySgVNMgUQSa5gm5WG4B8Tg8RWoW58miKXAeKCoNgAGji3og3uc3oI3uAfKAA).
 
 ## Map and Set Values Are Not Ordered by Insertion
 In TypeScript and JavaScript, `Map` and `Set` object values are kept in order by time of insertion when accessed. However, in roblox-ts, this is not the case for performance reasons, as [Maps are the only way we can represent all of the features of Lua tables](/docs/usage/workflow-issues#objects-may-only-have-string-keys).

--- a/_docs/usage/compiler-builtins.md
+++ b/_docs/usage/compiler-builtins.md
@@ -41,7 +41,7 @@ if typeof(x) == "Vector3" then
 end
 ```
 {% endcapture %}
-{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
+{% include tabs.html tabs="TypeScript,Lua" content=code %}
 
 ## `classIs`
 
@@ -62,7 +62,7 @@ if x and x:IsA("Model") then
 end
 ```
 {% endcapture %}
-{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
+{% include tabs.html tabs="TypeScript,Lua" content=code %}
 
 ## `opcall`
 
@@ -146,7 +146,7 @@ Currently, there is only one well-known symbol:
   print(unpack(TS.iterableCache(x[TS.Symbol_iterator](x))));
   ```
   {% endcapture %}
-  {% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
+  {% include tabs.html tabs="TypeScript,Lua" content=code %}
   
 ### Methods
 

--- a/_docs/usage/compiler-builtins.md
+++ b/_docs/usage/compiler-builtins.md
@@ -25,6 +25,7 @@ This function maps directly to Roblox's `typeof` function. The reason for this d
 
 This function is a type guard form of `typeOf`, which provides type narrowing. `typeIs` is compatible with any type that Lua's `typeof` function is compatible with. 
 
+{% capture code %}
 ```ts
 const x = new Vector3() as unknown; // "unknown"
 
@@ -32,17 +33,36 @@ if (typeIs(x, "Vector3")) {
   x; // "Vector3"
 }
 ```
+***
+```lua
+local x = Vector3.new()
+if typeof(x) == "Vector3" then
+  -- You can reference Vector3 here without TypeScript complaints
+end
+```
+{% endcapture %}
+{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
 
 ## `classIs`
 
 `classIs` is similar to `typeIs`, but provides type narrowing for Instances via the `ClassName` property. Comparing the `ClassName` property by hand does not provide such narrowing, because TypeScript's structural typing makes implementation difficult and complex. The `classIs` function is a compromise that keeps things simple while still offering `ClassName` narrowing: 
 
+{% capture code %}
 ```ts
 const x = game.FindFirstChild("X");
 if (x && classIs(x, "Model")) {
   x.BreakJoints();
 }
 ```
+***
+```lua
+local x = game:FindFirstChild("X")
+if x and x:IsA("Model") then
+  x:BreakJoints()
+end
+```
+{% endcapture %}
+{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
 
 ## `opcall`
 
@@ -88,6 +108,7 @@ Currently, there is only one well-known symbol:
 - `Symbol.iterator`
   - If this symbol is added as a method of an object or class, that object can then be directly iterated over in spread syntax (`...`) or `for..of` loops.
 
+  {% capture code %}
   ```ts
     const x = {
       [Symbol.iterator]: function*() {
@@ -99,7 +120,34 @@ Currently, there is only one well-known symbol:
 
   print(...x);
   ```
-
+  ***
+  ```lua
+  local x = {
+	  [TS.Symbol_iterator] = function(self)
+		  return {
+			  next = coroutine.wrap(function()
+				  coroutine.yield({
+					  value = 1;
+					  done = false;
+				  });
+				  coroutine.yield({
+					  value = 2;
+					  done = false;
+				  });
+				  coroutine.yield({
+					  value = 3;
+					  done = false;
+				  });
+				  while true do coroutine.yield({ done = true }) end;
+			  end);
+		  };
+	  end;
+  };
+  print(unpack(TS.iterableCache(x[TS.Symbol_iterator](x))));
+  ```
+  {% endcapture %}
+  {% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
+  
 ### Methods
 
 - `Symbol.for`

--- a/_docs/usage/types.md
+++ b/_docs/usage/types.md
@@ -61,7 +61,7 @@ local values = { returnsMultipleValues() }
 local theString, theNumber = returnsMultipleValues()
 ```
 {% endcapture %}
-{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
+{% include tabs.html tabs="TypeScript,Lua" content=code %}
 
 You can also have your regular (non-declared) functions return a `LuaTuple<T>`, which functions semantically identically if you wish to write a function that returns multiple values with TypeScript.
 
@@ -79,7 +79,7 @@ x; // hovering over X reveals "number", even though it's really a string.
 local x = "not a number" -- This does not have any noticeable effect on the compiled Lua code.
 ```
 {% endcapture %}
-{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
+{% include tabs.html tabs="TypeScript,Lua" content=code %}
 
 Type assertions should be avoided and only used as a last resort when you are unable to express types with any other mechanism. Abuse of type assertions can lead to unexpected behavior and bugs because type soundness will no longer be guaranteed.
 
@@ -94,7 +94,7 @@ const maybePart = workspace.FindFirstChild<Part>("Baseplate"); // Part | undefin
 local maybePart = workspace:FindFirstChild("Baseplate")
 ```
 {% endcapture %}
-{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
+{% include tabs.html tabs="TypeScript,Lua" content=code %}
 
 This form is available for many methods in the API, such as `CollectionService.GetTagged`, `GetChildren`, `WaitForChild`, data stores, etc. You should prefer using this generic form instead of using a type assertion.
 
@@ -111,7 +111,7 @@ const part = workspace.FindFirstChild<Part>("Baseplate")!; // Part
 local part = workspace:FindFirstChild("Baseplate")
 ```
 {% endcapture %}
-{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
+{% include tabs.html tabs="TypeScript,Lua" content=code %}
 
 # Constructors
 
@@ -130,7 +130,7 @@ const part = workspace.FindFirstChild<Part>("Baseplate")!; // Part
 local part = workspace:FindFirstChild("Baseplate")
 ```
 {% endcapture %}
-{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
+{% include tabs.html tabs="TypeScript,Lua" content=code %}
 
 You can also [define a typed instance tree with intersection types](/docs/guides/indexing-children) to enable dot indexing for ergonomic usage.
 
@@ -156,7 +156,7 @@ if (typeof(x) == "Vector3") then
 end;
 ```
 {% endcapture %}
-{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
+{% include tabs.html tabs="TypeScript,Lua" content=code %}
 
 See also: [Compiler Built-ins](/docs/usage/compiler-builtins)
 {:.info}

--- a/_docs/usage/workflow-issues.md
+++ b/_docs/usage/workflow-issues.md
@@ -40,6 +40,6 @@ local playerMap = {}
 playerMap[somePlayer] = 5;
 ```
 {% endcapture %}
-{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
+{% include tabs.html tabs="TypeScript,Lua" content=code %}
 
 [`Set`](/types/interfaces/_es_d_.set.html) is another useful data type that holds a set of unique values. It is akin to an array, but uniqueness is enforced.

--- a/_docs/usage/workflow-issues.md
+++ b/_docs/usage/workflow-issues.md
@@ -29,9 +29,17 @@ However, a `ModuleScript` inside of `game.ServerStorage` should not be accessibl
 ## Objects May Only Have String Keys
 In TypeScript, objects may only have string keys, and arrays may only have numerical keys. This contrasts heavily with the wild west of Lua tables, where the keys can be mixed and of any type. In roblox-ts (and TypeScript), we can solve this problem by using a [`Map`](/types/interfaces/_es_d_.map.html) object. Maps are objects that hold arbitrary key-value pairs of data. They also support generic types:
 
+{% capture code %}
 ```ts
 const playerMap = new Map<Player, number>()
 playerMap.set(somePlayer, 5)
 ```
+***
+```lua
+local playerMap = {}
+playerMap[somePlayer] = 5;
+```
+{% endcapture %}
+{% include tabs.html sync="lua" tabs="TypeScript,Lua" content=code %}
 
 [`Set`](/types/interfaces/_es_d_.set.html) is another useful data type that holds a set of unique values. It is akin to an array, but uniqueness is enforced.


### PR DESCRIPTION
I think it's an excellent learning resource for players to see how the code will compile before they actually try it themselves, so they can get a deeper understanding of how their code will run in Roblox.

Also made it clearer that interfaces don't directly compile into anything in a side-note
And changed the playground link to be a relative path.