### PR TITLE
Updated example

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -19,8 +19,8 @@ for (const obj of CollectionService.GetTagged("Lava")) {
     obj.Touched.Connect(part => {
       const character = part.Parent;
       if (character) {
-        const humanoid = character.FindFirstChild("Humanoid");
-        if (humanoid && humanoid.IsA("Humanoid")) {
+        const humanoid = character.FindFirstChildOfClass("Humanoid");
+        if (humanoid) {
           humanoid.TakeDamage(100);
         }
       }


### PR DESCRIPTION
Updated example to use `FindFirstChildOfClass` instead of `FindFirstChild` and `IsA` as Humanoids aren't always named `Humanoid`