### PR TITLE
Fix cursor position when formatting in playground

### DIFF
--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -232,8 +232,9 @@ export default () => {
 					rangeStart: undefined,
 					rangeEnd: undefined,
 				});
-				editor.setPosition(model.getPositionAt(formatResult.cursorOffset));
+
 				model.setValue(formatResult.formatted);
+				editor.setPosition(model.getPositionAt(formatResult.cursorOffset));
 			});
 
 			setInputModel(model);


### PR DESCRIPTION
Sets the editor cursor position after the model has been updated with the formatted code instead of before. Currently, it resets your cursor position to 0,0 when formatting.