### PR TITLE
fix: Add 404 warning to /typescript-packages

### DIFF
--- a/docs/guides/typescript-packages.mdx
+++ b/docs/guides/typescript-packages.mdx
@@ -29,7 +29,8 @@ In `package.json`, you can edit a few different fields to configure your package
 The simplest way to test your package is with `npm pack`. This command will generate a `.tgz` file which can then be used from another project via `npm install ../../path/to/package.tgz`.
 
 :::warning
-When publishing a package for the first time, you might run into this issue:
+When publishing a package for the first time, you might run into these issues:
 
 [npm publish errors with "npm error 402 Payment Required"](../faq/publish-as-public)
+[npm publish errors with "npm error 404 Not Found"](../faq/publish-not-found)
 :::


### PR DESCRIPTION
Until the @rbxts npm group issue is fixed, people should know this is not a problem with `npm`.

I spent 2-3 hours trying to debug this thinking the issue was with my `npm` permissions or my `package.json`.