### PR TITLE
Add note on Roact documentation that it is deprecated

### DIFF
--- a/docs/guides/roact-jsx.mdx
+++ b/docs/guides/roact-jsx.mdx
@@ -1,6 +1,10 @@
 ---
 title: Roact JSX
 ---
+:::note
+**Roact is officially deprecated.**  
+If you're looking for an updated and maintained version, consider using [rbxts/react](https://github.com/littensy/rbxts-react/), which supersedes Roact.
+:::
 
 :::note
 The following guide assumes that you are already familiar with Roact. <br/>


### PR DESCRIPTION
Add deprecation note to ROACT usage page
Although I'd prefer to fully remove this page, I understand the value in keeping it around for legacy project support. That said, adding this note should help discourage new users from starting projects with ROACT just because it's still referenced in the docs.

We could use a more prominent warning instead of a simple note if we want to make it more obvious, but up to you.

At least this is a little nudge